### PR TITLE
Some additions

### DIFF
--- a/active_column.gemspec
+++ b/active_column.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib", "lib/active_column/types"]
 
   s.add_dependency 'cassandra', '>= 0.12'
-  s.add_dependency 'simple_uuid', '~> 0.1.0'
+  s.add_dependency 'simple_uuid', '~> 0.2.0'
   s.add_dependency 'rake'
 
   s.add_development_dependency 'rails', '>= 3.0'

--- a/active_column.gemspec
+++ b/active_column.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.require_paths = ["lib", "lib/active_column/types"]
 
   s.add_dependency 'cassandra', '>= 0.9'
-  s.add_dependency 'simple_uuid', '~> 0.1.0'
+  s.add_dependency 'simple_uuid', '>= 0.1.0'
   s.add_dependency 'rake'
 
   s.add_development_dependency 'rails', '>= 3.0'

--- a/lib/active_column.rb
+++ b/lib/active_column.rb
@@ -6,6 +6,7 @@ module ActiveColumn
 
   autoload :Base,           'active_column/base'
   autoload :Configuration,  'active_column/configuration'
+  autoload :Constants,	    'active_column/constants'
   autoload :KeyConfig,      'active_column/key_config'
   autoload :Version,        'active_column/version'
   autoload :Helpers,        'active_column/helpers'
@@ -17,6 +18,10 @@ module ActiveColumn
   module Tasks
     autoload :Keyspace,     'active_column/tasks/keyspace'
     autoload :ColumnFamily, 'active_column/tasks/column_family'
+  end
+
+  module Types
+    autoload :ColumnFamily, 'active_column/types/column_family'
   end
 
   load                      'active_column/tasks/ks.rake'

--- a/lib/active_column/constants.rb
+++ b/lib/active_column/constants.rb
@@ -1,0 +1,18 @@
+module ActiveColumn
+  module Constants
+    COMPARATOR_TYPES = { 
+      :time         => 'TimeUUIDType',
+      :timestamp    => 'TimeUUIDType',
+      :long         => 'LongType',
+      :string       => 'BytesType',
+      :utf8         => 'UTF8Type',
+      :lexical_uuid => 'LexicalUUIDType',
+      :double	    => 'DoubleType'
+    }
+
+    COLUMN_TYPES = { 
+      :super    => 'Super',
+      :standard => 'Standard' 
+    }
+  end
+end

--- a/lib/active_column/generators/templates/migration.rb.erb
+++ b/lib/active_column/generators/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= name %> < ActiveColumn::Migration
+class <%= name.camelcase %> < ActiveColumn::Migration
 
   def self.up
 

--- a/lib/active_column/types/column_family.rb
+++ b/lib/active_column/types/column_family.rb
@@ -6,7 +6,7 @@ module ActiveColumn
 
       def column(name, &block)	
 	cd = CassandraThrift::ColumnDef.new
-	cd.name = name
+	cd.name = name.to_s
 	block.call cd if block	
 	post_process_column_metadata(cd)
 	self.column_metadata << cd

--- a/lib/active_column/types/column_family.rb
+++ b/lib/active_column/types/column_family.rb
@@ -1,0 +1,25 @@
+module ActiveColumn
+  module Types
+    class ColumnFamily < Cassandra::ColumnFamily
+
+      include ActiveColumn::Constants
+
+      def column(name, &block)	
+	cd = CassandraThrift::ColumnDef.new
+	cd.name = name
+	block.call cd if block	
+	post_process_column_metadata(cd)
+	self.column_metadata << cd
+      end	
+
+      private
+
+      def post_process_column_metadata(cd)
+	validation_class = cd.validation_class
+	if validation_class && COMPARATOR_TYPES.has_key?(validation_class)
+	  cd.validation_class = COMPARATOR_TYPES[validation_class]
+	end	  
+      end
+    end 
+  end
+end


### PR DESCRIPTION
Hey there,

I made some changes to your active_column gem:
- I changed the requirement for the simple_uuid gem from ~> 0.1.0 to >= 0.1.0
- You can now use a block to define column metadata like this:
  create_column_family :Test do |cf|
  cf.column :mycolumn do |cd|
    cd.validation_class = :utf8
  end
  end
- Symbols for "comparator_type", "default_validation_class", "key_validation_class" are now correctly converted to COMPARATOR_TYPES strings.
