### PR TITLE
Update required version of cassandra gem

### DIFF
--- a/active_column.gemspec
+++ b/active_column.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'cassandra', '>= 0.9'
+  s.add_dependency 'cassandra', '>= 0.12.2'
   s.add_dependency 'simple_uuid', '~> 0.1.0'
   s.add_dependency 'rake'
 


### PR DESCRIPTION
The version of cassandra required before (0.9) didn't work using thrift 0.7 due
to bug https://issues.apache.org/jira/browse/THRIFT-1382 . It works with 0.12.2 again, which pulls thrift 0.8.
