### PR TITLE
Fix the SimpleUUID to string conversion for SimpleUUID 0.2

### DIFF
--- a/active_column.gemspec
+++ b/active_column.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'cassandra', '>= 0.12'
-  s.add_dependency 'simple_uuid', '~> 0.1.0'
+  s.add_dependency 'simple_uuid', '>= 0.1.0'
   s.add_dependency 'rake'
 
   s.add_development_dependency 'rails', '>= 3.0'

--- a/lib/active_column/base.rb
+++ b/lib/active_column/base.rb
@@ -54,7 +54,7 @@ module ActiveColumn
   end
 
   def save()
-    value = { SimpleUUID::UUID.new => self.to_json }
+    value = { SimpleUUID::UUID.new.to_s => self.to_json }
     key_parts = self.class.keys.each_with_object( {} ) do |key_config, key_parts|
       key_parts[key_config.key] = self.send(key_config.func)
     end


### PR DESCRIPTION
SimpleUUID 0.2 is needed for the newer cassandra gems, but throws an error if not converted to a string before being passed. 
