### PR TITLE
Fix up KeySpace tasks to use the supplied config

### DIFF
--- a/lib/active_column/tasks/keyspace.rb
+++ b/lib/active_column/tasks/keyspace.rb
@@ -29,6 +29,9 @@ module ActiveColumn
           return nil
         end
 
+        # YAML gives us hashes as String => Value, but Cassandra expects Symbol => Value
+        options = Hash[ options.map { |k,v| [k.to_sym, v] } ]
+
         opts = { :name => name.to_s,
                  :strategy_class => 'org.apache.cassandra.locator.SimpleStrategy',
                  :replication_factor => 1,


### PR DESCRIPTION
Comment in the code explains the fix, YAML returns the config hash as String=>Value, but when working out the settings for the KeySpace creation task, you merge it with a has that is Symbol=>Value.

This fix ensures that we always use the Symbol=>Value version (which is what the Cassandra gem wants as well).

I needed this fix to get the 0.2 version of your gem to work with Cassandra 1.1 where LocalStrategy is no longer allowed.  The other thing I had to change was to use:

``` yaml
test:
  servers: "127.0.0.1:9160"
  keyspace: "myapp_test"
  strategy_class: "SimpleStrategy"
  strategy_options: { replication_factor: "1" }
  thrift:
    timeout: 3
    retries: 2
```

Since Cassandra 1.1 no longer lets you pass the replication factor in on it's own, it has to be embedded in the `strategy_options` hash... 
