### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Disable dependabot updates…
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Looks like this repository has not been updated for a while, what do folks think of disabling dependabot for now to reduce the number of Github notifications?